### PR TITLE
Fixed composer `require` command path

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cv pop /path/to/pop.yml
 
 Pop is also available via composer:
 
-`composer require michaelmcandrew\pop`
+`composer require michaelmcandrew/pop`
 
 ## Syntax
 


### PR DESCRIPTION
Don't know much about composer, but the back-slash fails for me on Ubuntu 15.04, while the forward-slash succeeds.